### PR TITLE
Add automated release image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ RUN set -o errexit; \
   ./ci/scripts/build-code.sh
 
 FROM registry.hub.docker.com/library/alpine:3.11
-ARG BUILT_FROM_REF=latest
 
 COPY --from=build /build/gups /usr/local/bin/gups
 
 ENV CONFIG=/etc/gups/config.json
-LABEL maintainer=remi.attab@gmail.com BUILT_FROM_REF=${BUILT_FROM_REF}
+LABEL maintainer=remi.attab@gmail.com
 ENTRYPOINT [ "/usr/local/bin/gups" ]

--- a/ci/pipelines/gups.yml
+++ b/ci/pipelines/gups.yml
@@ -1,0 +1,32 @@
+resources:
+  - name: gups-repo
+    type: git
+    source:
+      uri: https://github.com/rattab/gups
+      tag_filter: '*.*.*'
+      check_every: 24h
+
+  - name: gups-image
+    type: docker-image
+    source:
+      repository: registry.hub.docker.com/adgear/gups
+      username: ((dockerhub.username))
+      password: ((dockerhub.access_token))
+
+jobs:
+  - name: build-image
+    plan:
+      - get: gups-repo
+        version: every
+        trigger: true
+
+      - task: generate-metadata
+        file: gups-repo/ci/tasks/generate-metadata.yml
+
+      - put: gups-image
+        params:
+          build: gups-repo
+          tag_file: build-metadata/tag
+          additional_tags: build-metadata/additionnal_tags
+          labels_file: build-metadata/labels.json
+          tag_as_latest: true

--- a/ci/scripts/build-image.sh
+++ b/ci/scripts/build-image.sh
@@ -9,7 +9,7 @@ if git describe --exact-match HEAD && git diff --quiet; then
   minor="$(echo "${tag}" | cut -d. -f2)"
 
   docker build \
-    --build-arg "BUILT_FROM_REF=$(git rev-parse HEAD)" \
+    --label "BUILT_FROM_REF=$(git rev-parse HEAD)" \
     -t registry.hub.docker.com/rattab/gups:latest \
     -t "registry.hub.docker.com/rattab/gups:${tag}" \
     -t "registry.hub.docker.com/rattab/gups:${major}" \
@@ -17,7 +17,7 @@ if git describe --exact-match HEAD && git diff --quiet; then
     .
 else
   docker build \
-    --build-arg "BUILT_FROM_REF=$(git rev-parse HEAD)" \
+    --label "BUILT_FROM_REF=$(git rev-parse HEAD)" \
     -t "registry.hub.docker.com/rattab/gups:dev-$(date +%s)" \
     .
 fi

--- a/ci/scripts/output-ci-metadata.sh
+++ b/ci/scripts/output-ci-metadata.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+set -o errexit \
+    -o pipefail
+
+artifact_dest="${artifact_dest:-build-metadata}"
+
+log() {
+  printf "${@}" >&2
+}
+
+cd gups-repo || exit 1
+
+log 'sha: '
+sha="$(git rev-parse | tee "../${artifact_dest}/sha")"
+
+log 'tag: '
+tag="$(git describe --exact-match --tags HEAD | tee "../${artifact_dest}/tag")"
+
+major="$(printf "%s" "${tag}" | cut -d. -f1)"
+minor="$(printf "%s" "${tag}" | cut -d. -f2)"
+
+log 'additionnal_tags: '
+echo "${major} ${major}.${minor}" | tee "../${artifact_dest}/additionnal_tags"
+
+sha="$(git rev-parse HEAD)"
+
+log "labels.json: \n"
+tee "../${artifact_dest}/labels.json" <<EOF
+{
+  "BUILT_FROM_REF": "${sha}"
+}
+EOF

--- a/ci/tasks/generate-metadata.yml
+++ b/ci/tasks/generate-metadata.yml
@@ -1,0 +1,26 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: '3.11'
+
+run:
+  path: /bin/sh
+  args:
+    - -c
+    - |
+      set -o errexit
+
+      printf 'installing dependencies ...' >&2
+      apk add -U bash git > /dev/null 2>&1
+      printf " done\n" >&2
+
+      gups-repo/ci/scripts/output-ci-metadata.sh
+
+inputs:
+  - name: gups-repo
+
+outputs:
+  - name: build-metadata


### PR DESCRIPTION
This PR adds automated image builds with AdGear's Concourse build system. The image would be hosted for now under [AdGear's DockerHub account][dh-ag].

Merging this is going to require a new release tag for CI to build properly.